### PR TITLE
fix: restriccion send chat requests (task#141-backend)

### DIFF
--- a/main/chat/views.py
+++ b/main/chat/views.py
@@ -24,7 +24,7 @@ def send_chat_request(request, cuidador_id, offer_id):
     cuidador = get_object_or_404(Cuidador, id=cuidador_id)
     oferta = get_object_or_404(Offer, id=offer_id)
     # Verifica si ya existe una solicitud pendiente para esta oferta
-    existing_request = ChatRequest.objects.filter(sender=cliente.user, receiver=cuidador.user,accepted=False,offer=oferta).first()
+    existing_request = ChatRequest.objects.filter(sender=cliente.user, receiver=cuidador.user, offer=oferta).first()
     if not existing_request:
         # Si no existe, crea una nueva solicitud con la oferta asociada
         ChatRequest.objects.create(sender=cliente.user, receiver=cuidador.user, offer=oferta)


### PR DESCRIPTION
Si ya te han aceptado la solicitud de chat, no se enviará otra si lo intentas. Antes no dejaba enviar varias solicitudes si no te la habían aceptado, pero si te la aceptaban podías enviar otra solicitud a la misma oferta, lo cual generaba que pudieras tener chats duplicados.